### PR TITLE
Add support for response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ FakeServer.Status.create(:status200, %{response_code: 200, response_body: ~s<"us
 FakeServer.Status.create(:status500, %{response_code: 500, response_body: ~s<"error": "internal server error">})
 FakeServer.Status.create(:status403, %{response_code: 403, response_body: ~s<"error": "forbidden">})
 
+# you can also pass `response_header` (optional):
+FakeServer.Status.create(:status200, %{response_code: 200, response_body: "OK", resonse_headers: %{"Conent-Length": 5}})
+
 
 ### test/user_test.exs
 defmodule UserTest do
@@ -53,7 +56,7 @@ defmodule UserTest do
       FakeServer.stop(:external_server)
     end
   end
-  
+
   test "#get returns user if the external server responds 200" do
     # add the status sequence will want the server to respond with
     # the fake server will respond with the first status on the list
@@ -65,14 +68,14 @@ defmodule UserTest do
     # make the request to the fake server and validate it works
     assert User.get == %{username: "mr_user"}
   end
-  
+
   test "#get retry up to 3 times when external server responds with 500" do
     {:ok, address} = FakeServer.modify_behavior(:external_server, [:status500, :status500, :status500, :status200])
 
     # you can easily test a retry scenario, where one call to the external service makes multiple requests
     assert User.get == %{username: "mr_user"}
   end
-  
+
   test "#get returns timeout after 3 retries" do
     # another retry example, this time with a timeout scenario
     {:ok, address} = FakeServer.modify_behavior(:external_server, [:status500, :status500, :status500, :status500])

--- a/lib/fake_server/behavior.ex
+++ b/lib/fake_server/behavior.ex
@@ -5,7 +5,7 @@ defmodule FakeServer.Behavior do
     name
     |> validate_name
     |> validate_status_list(status_list)
-  end 
+  end
 
   def destroy(name) do
     case Process.whereis(name) do
@@ -19,7 +19,7 @@ defmodule FakeServer.Behavior do
   def next_response(name) do
     case Agent.get(name, fn(status_list) -> List.first(status_list) end) do
       nil -> {:ok, :no_more_status}
-      response -> 
+      response ->
         update_pipeline(name)
         {:ok, response}
     end
@@ -28,7 +28,7 @@ defmodule FakeServer.Behavior do
   def modify(_name, []), do: {:error, :no_status}
   def modify(name, status_list) do
     case validate_status(status_list) do
-      :ok -> 
+      :ok ->
         try do
           Agent.update(name, fn(_old_status_list) -> status_list end)
         catch
@@ -64,7 +64,7 @@ defmodule FakeServer.Behavior do
   end
 
   defp check_current_status(status) do
-    status  
+    status
     |> check_status_name
     |> check_status_existence
   end
@@ -72,7 +72,7 @@ defmodule FakeServer.Behavior do
   defp check_status_name(status) do
     FakeServer.Status.validate_name(status)
   end
-  
+
   defp check_status_existence({:error, reason}), do: {:error, reason}
   defp check_status_existence(status) do
     case FakeServer.Status.get(status) do

--- a/lib/fake_server/handler.ex
+++ b/lib/fake_server/handler.ex
@@ -24,7 +24,7 @@ defmodule FakeServer.Handler do
   defp default_response, do: %{response_code: 200, response_body: ~s<"status": "no more actions">}
 
   defp get_response(response) do
-    case FakeServer.Status.get(response) do    
+    case FakeServer.Status.get(response) do
       {:ok, response} -> response
       {:error, reason} -> {:error, reason}
     end
@@ -32,7 +32,7 @@ defmodule FakeServer.Handler do
 
   defp respond_accordingly({:error, reason}, _conn), do: {:error, reason}
   defp respond_accordingly(response, conn) do
-    case :cowboy_req.reply(response[:response_code], [], response[:response_body], conn) do
+    case :cowboy_req.reply(response[:response_code], response[:response_headers], response[:response_body], conn) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end

--- a/test/fake_server/behavior_test.exs
+++ b/test/fake_server/behavior_test.exs
@@ -6,9 +6,9 @@ defmodule FakeServer.BehaviorTest do
   @invalid_status_list [:status_200, :status_400, :invalid]
 
   setup_all do
-      FakeServer.Status.create(:status_200, %{response_code: 200, response_body: ~s<"user": "Test", "age": 25>})
-      FakeServer.Status.create(:status_400, %{response_code: 400, response_body: ~s<"error": "bad request">})
-      FakeServer.Status.create(:timeout, %{response_code: 408, response_body: ~s<"error": "request timeout">})
+    FakeServer.Status.create(:status_200, %{response_code: 200, response_body: ~s<"user": "Test", "age": 25>})
+    FakeServer.Status.create(:status_400, %{response_code: 400, response_body: ~s<"error": "bad request">})
+    FakeServer.Status.create(:timeout, %{response_code: 408, response_body: ~s<"error": "request timeout">})
     :ok
   end
 
@@ -19,11 +19,11 @@ defmodule FakeServer.BehaviorTest do
   end
 
   test "#create does not returns error if no status are provided" do
-    assert FakeServer.Behavior.create(:test_behavior, []) == {:ok, :test_behavior} 
+    assert FakeServer.Behavior.create(:test_behavior, []) == {:ok, :test_behavior}
   end
 
   test "#create returns error on the first invalid status" do
-    assert FakeServer.Behavior.create(:test_behavior, @invalid_status_list) == {:error, {:invalid_status, :invalid}} 
+    assert FakeServer.Behavior.create(:test_behavior, @invalid_status_list) == {:error, {:invalid_status, :invalid}}
   end
 
   test "#create returns error when name already exists" do
@@ -51,7 +51,7 @@ defmodule FakeServer.BehaviorTest do
     assert FakeServer.Behavior.next_response(:test_behavior) == {:ok, :timeout}
   end
 
-  test "#next_response returns behavior_empty if there is no more status on behavior list" do
+  test "#next_response returns no_more_status if there is no more status on behavior list" do
     FakeServer.Behavior.create(:test_behavior, @valid_status_list)
     FakeServer.Behavior.next_response(:test_behavior)
     FakeServer.Behavior.next_response(:test_behavior)
@@ -65,7 +65,7 @@ defmodule FakeServer.BehaviorTest do
   end
 
   test "#modify returns server not found if server name does not exist" do
-    assert FakeServer.Behavior.modify(:test_behavior, [:status_200]) == {:error, :server_not_found} 
+    assert FakeServer.Behavior.modify(:test_behavior, [:status_200]) == {:error, :server_not_found}
   end
 
   test "#modify returns error if status list is invalid" do

--- a/test/fake_server/status_test.exs
+++ b/test/fake_server/status_test.exs
@@ -30,19 +30,27 @@ defmodule FakeServer.StatusTest do
 
   test "#create put a new behavior on the list" do
     assert FakeServer.Status.create(:test, @valid_behavior) == :ok
-    assert Agent.get(FakeServer.Status, fn(list) -> list end) == [test: @valid_behavior]
+    assert Agent.get(FakeServer.Status, fn(list) -> list end) == [test: Map.put(@valid_behavior, :response_headers, [])]
+    FakeServer.Status.destroy_all
+  end
+
+  test "#create accepts response_headers option" do
+    assert FakeServer.Status.create(:with_headers, Map.put(@valid_behavior, :response_headers, %{"Content-Length": 5})) == :ok
+    assert Agent.get(FakeServer.Status, fn(list) -> list end) == [with_headers: Map.put(@valid_behavior, :response_headers, ["Content-Length": 5])]
     FakeServer.Status.destroy_all
   end
 
   test "#get returns all behaviors" do
     FakeServer.Status.create(:test, @valid_behavior)
-    assert FakeServer.Status.get == {:ok, [test: @valid_behavior]}
+    behaviour_with_headers = Map.put_new(@valid_behavior, :response_headers, [])
+    assert FakeServer.Status.get == {:ok, [test: behaviour_with_headers]}
     FakeServer.Status.destroy_all
   end
 
   test "#get(name) returns behaviors by name" do
     FakeServer.Status.create(:test, @valid_behavior)
-    assert FakeServer.Status.get(:test) == {:ok, @valid_behavior}
+    behaviour_with_headers = Map.put_new(@valid_behavior, :response_headers, [])
+    assert FakeServer.Status.get(:test) == {:ok, behaviour_with_headers}
     FakeServer.Status.destroy_all
   end
 

--- a/test/fake_server_test.exs
+++ b/test/fake_server_test.exs
@@ -35,12 +35,12 @@ defmodule FakeServerTest do
     assert FakeServer.run(:external, [:status_200]) == {:error, :already_exists}
     FakeServer.stop(:external)
   end
-  
+
   test "#run return error when one or more invalid status are passed as argument" do
     assert FakeServer.run(:external, [:status_200, :some_status]) == {:error, {:invalid_status, :some_status}}
     FakeServer.stop(:external)
   end
-  
+
   test "#run return error when one or more status name are not atoms" do
     assert FakeServer.run(:external, ["some_status"]) == {:error, {:invalid_status_name, "some_status"}}
     FakeServer.stop(:external)
@@ -85,7 +85,7 @@ defmodule FakeServerTest do
 
   test "#modify_behavior returns invalid_status_name if one or more status name are invalid" do
     FakeServer.run(:external, [])
-    assert FakeServer.modify_behavior(:external, "status_invalid") == {:error, {:invalid_status_name, "status_invalid"}} 
+    assert FakeServer.modify_behavior(:external, "status_invalid") == {:error, {:invalid_status_name, "status_invalid"}}
     FakeServer.stop(:external)
   end
 


### PR DESCRIPTION
Implements #15 

There're several questions I'm not very certain about: 
- how to test cowboy request params correctly in `test/fake_server/handler_test.exs`. Now I did it with simple param matching.
- how come that 
```elixir
def create(name, status = %{response_code: _code, response_body: _body}) do
```
pattern matches status with `response_headers` as well? 

Any help appreciated ;)