### PR TITLE
Add support to functions on routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,265 +1,63 @@
 # FakeServer
 [![Build Status](https://travis-ci.org/bernardolins/fake_server.svg?branch=master)](https://travis-ci.org/bernardolins/fake_server)
 [![Coverage Status](https://coveralls.io/repos/github/bernardolins/fake_server/badge.svg?branch=master)](https://coveralls.io/github/bernardolins/fake_server?branch=master)
+[![Hex.pm](https://img.shields.io/hexpm/dt/fake_server.svg)](https://hex.pm/packages/fake_server)
 [![Inline docs](http://inch-ci.org/github/bernardolins/fake_server.svg?branch=master&style=shields)](http://inch-ci.org/github/bernardolins/fake_server)
 
-FakeServer makes it easy to create mocks for HTTP servers in your tests. It integrates very well with ExUnit, but can also be used as a standalone server.
+With FakeServer you can create individual HTTP servers each test case, allowing external requests to be tested without the need for mocks. It integrates well with ExUnit, keeping the tests clean and readable.
 
-Following this README you will see some basic examples of usage. More details can be found in the documentation available on [Hexdocs](https://hexdocs.pm/fake_server/api-reference.html).
-
-**Important:** This README follows the master branch, that may not have been published yet. Therefore, information contained herein may not be present in the docs.
+There is an [example application](https://github.com/bernardolins/exfootball) that uses FakeServer and contains several usage examples. The [docs](https://hexdocs.pm/fake_server/api-reference.html) also shows more details of all the features available in the library.
 
 ## Installation
 
-FakeServer is available on [Hex](https://hex.pm/packages/fake_server). All you have to do is to add it to `mix.exs` as a test dependency.
+FakeServer is available on [Hex](https://hex.pm/packages/fake_server). First, add it to `mix.exs` as a test dependency:
 
 ```elixir
 def deps do
-  [{:fake_server, "~> 1.3", only: :test}]
+  [
+    {:fake_server, "~> 1.3", only: :test}
+  ]
 end
 ```
 
-Start `fake_server` application on `test/test_helper.exs`
+Then, start `fake_server` application on `test/test_helper.exs`.
 
 ```elixir
 {:ok, _} = Application.ensure_all_started(:fake_server)
 ```
 
-## ExUnit integration
+## Basic Usage
 
-To use FakeServer together with ExUnit, simply write your tests using the `test_with_server` macro.
+FakeServer provides the macro `FakeServer.test_with_server`. It works like ExUnit's `test` macro, but before your test starts it will run an HTTP server in a random port (by default). The server will be available until test case is finished.
 
-### Running a test with a server
-`test_with_server`, starts an HTTP server, initially without any route configured (that is, any request will be replied with 404).
-
-```elixir
-test_with_server "server will always reply 404 without any route configured", do
-  response = HTTPoison.get! FakeServer.address <> "/"
-  assert response.status_code == 404
-
-  response = HTTPoison.get! FakeServer.address <> "/any/route"
-  assert response.status_code == 404
-
-  response = HTTPoison.get! FakeServer.address <> "/another/route"
-  assert response.status_code == 404
-end
-```
-
-### Adding routes
-
-You can add routes to your server through the `route` macro.
-
-A route can reply a request in 3 ways:
-  1. directly returning the a [%FakeServer.HTTP.Response{}](https://hexdocs.pm/fake_server/FakeServer.HTTP.Response.html) structure;
-  2. iterating a list of [%FakeServer.HTTP.Response{}](https://hexdocs.pm/fake_server/FakeServer.HTTP.Response.html) structures;
-  3. querying a [FakeController](https://hexdocs.pm/fake_server/FakeController.html).
-
-#### With a single response
+You can use the `FakeServer.route` macro to add a route and setup it's response. Use `FakeServer.address` to get the address of the server running in the current test.
 
 ```elixir
-# test/my_app/some_module_test.exs
+# extracted from https://github.com/bernardolins/exfootball
 
-describe "with a single response element" do
-  test_with_server "reply with this element once and then uses a default response" do
-    route "/test", do: Response.bad_request
+defmodule Exfootball.External.FootballDataTest do
+  use ExUnit.Case
+  import FakeServer
 
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 400
+  alias Exfootball.External.FootballData
 
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 200
-    assert response.body == "This is a default response from FakeServer"
-  end
+  describe "#list_competitions" do
+    test_with_server "returns a map with the same size of the list of competitions replied by football-data api" do
+      Application.put_env(:exfootball, :football_data_api_url, "http://#{FakeServer.address}")
 
-  test_with_server "this default response can be configured", [default_response: Response.forbidden] do
-    route "/test", do: Response.bad_request
+      route "/competitions", FakeServer.HTTP.Response.ok([
+           %{id: 444, caption: "Campeonato Brasileiro da Série A"},
+           %{id: 445, caption: "Premier League 2017/18"},
+           %{id: 446, caption: "Championship 2017/18"}
+          ],
+          %{"content-type" => "application/json"}
+        )
+      end
 
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 400
-
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 403
-  end
-end
-```
-
-#### With a list of responses
-
-```elixir
-# test/my_app/some_module_test.exs
-
-describe "with a list of responses" do
-  test_with_server "responds with the first element until the list empties, and then uses a default response" do
-    route "/test", do: [Response.ok, Response.not_found, Response.bad_request]
-
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 200
-
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 404
-
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 400
-
-    # reply the default_response when the list empties
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 200
-    assert response.body == "This is a default response from FakeServer"
-  end
-
-  test_with_server "this default response can be configured", [default_response: Response.forbidden] do
-    route "/test", do: []
-
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 403
-
-    response = HTTPoison.get! FakeServer.address <> "/test"
-    assert response.status_code == 403
-  end
-end
-```
-
-#### With FakeControllers
-With FakeControllers you can analyze the content of the request and choose the type of response dynamically.
-
-A controller is a special function that is executed every time a route configured with it receives a request.
-
-```elixir
-# test/support/fake_controllers.ex
-
-# Create a module with your controllers and use the
-# FakeController.__using__ macro on this module
-defmodule FakeServer.Integration.FakeControllers do
-  use FakeController
-
-  # Controller names must end in _controller
-  # Also, they receive a single argument
-  # They must return an %FakeServer.HTTP.Response struct
-  def query_string_controller(conn) do
-    if :cowboy_req.qs_val("token", conn) |> elem(0) == "1234" do
-      FakeServer.HTTP.Response.ok
-    else
-      FakeServer.HTTP.Response.unauthorized
+      assert Enum.count(FootballData.list_competitions) == 3
     end
   end
 end
-
-# test/my_app/some_test.exs
-
-test_with_server "evaluates FakeController and reply accordingly" do
-  # Every time a request arrives at root path, the controller
-  # will be executed to determine which response should be given
-  # Note that _controller is not needed on the controller name this time!
-  route "/", do: use_controller :query_string
-
-  response = HTTPoison.get! FakeServer.address <> "/"
-  assert response.status_code == 401
-
-  response = HTTPoison.get! FakeServer.address <> "/?token=1234"
-  assert response.status_code == 200
-end
 ```
 
-### Response Factories
-With response factories it is possible to create a default format of a given response and identify it with a name so that it can be shared across several test cases.
-
-They are inspired by the [ExMachina's factories](https://github.com/thoughtbot/ex_machina), and were created to suit the use case where it is necessary to modify both the body or headers of a given response while testing different scenarios.
-
-```elixir
-# test/support/fake_response_factory.ex
-defmodule FakeResponseFactory do
-  use FakeServer.ResponseFactory
-
-  def person_response do
-    ok(%{
-      name: Faker.Name.name,
-      email: Faker.Internet.free_email,
-      company: %{name: Faker.Company.name, county: Faker.Address.country}
-    }, %{"Content-Type" => "application/json"})
-  end
-
-  def customized_404_response do
-    not_found(%{message: "This item was not found!"}, %{"Content-Type" => "application/json"})
-  end
-end
-
-# test/my_app/some_test.exs
-defmodule FakeServer.FakeServerIntegrationTest do
-  use ExUnit.Case, async: false
-
-  import FakeServer
-
-  test_with_server "generates a response wiht custom data" do
-    customized_response = %{body: person} = FakeResponseFactory.build(:person)
-
-    route "/person", do: customized_response
-
-    response = HTTPoison.get! FakeServer.address <> "/person"
-    body = Poison.decode!(response.body)
-
-    assert response.status_code == 200
-    assert person[:name] == body["name"]
-    assert person[:email] == body["email"]
-    assert person[:company][:name] == body["company"]["name"]
-    assert person[:company][:country] == body["company"]["country"]
-  end
-
-  test_with_server "can set some attributes for the built response body" do
-    route "/person", do: FakeResponseFactory.build(:person, name: "John", email: "john@myawesomemail.com")
-
-    response = HTTPoison.get! FakeServer.address <> "/person"
-    body = Poison.decode!(response.body)
-
-    assert response.status_code == 200
-    assert body["name"] == "John"
-    assert body["email"] == "john@myawesomemail.com"
-  end
-
-  test_with_server "can set custom response headers" do
-    route "/person", do: FakeResponseFactory.build(:person, %{"Content-Type" => "application/x-www-form-urlencoded"})
-
-    response = HTTPoison.get! FakeServer.address <> "/person"
-
-    assert response.status_code == 200
-    assert Enum.any?(response.headers, fn(header) -> header == {"Content-Type", "application/x-www-form-urlencoded"} end)
-  end
-
-  test_with_server "create a list of responses" do
-    person_list = FakeResponseFactory.build_list(3, :person)
-
-    route "/person", do: person_list
-
-    Enum.each(person_list, fn(person) ->
-      response = HTTPoison.get! FakeServer.address <> "/person"
-      body = Poison.decode!(response.body)
-
-      assert response.status_code == 200
-      assert person.body[:name] == body["name"]
-      assert person.body[:email] == body["email"]
-      assert person.body[:company][:name] == body["company"]["name"]
-      assert person.body[:company][:country] == body["company"]["country"]
-    end)
-  end
-end
-```
-### Server configuration
-
-The `test_with_server` macro accepts a keyword list with arguments to the server that will be created.
-
-```elixir
-# test/my_app/some_test.exs
-test_with_server "accepts the port argument to configure a custom port for the server", [port: 5001] do
-  assert FakeServer.address == "127.0.0.1:5001"
-
-  route "/", do: Response.bad_request
-
-  response = HTTPoison.get! "127.0.0.1:5001" <> "/"
-  assert response.status_code == 400
-end
-
-test_with_server "accepts the default_response argument to configure the server default response", [default_response: Response.bad_request] do
-  route "/", do: []
-  response = HTTPoison.get! FakeServer.address <> "/"
-  assert response.status_code == 400
-end
-```
+For more examples see the [docs](https://hexdocs.pm/fake_server/api-reference.html) or the [example application](https://github.com/bernardolins/exfootball), which uses [Tesla](https://github.com/teamon/tesla) to request [football-data](https://www.football-data.org/docs/v1/index.html) api.

--- a/lib/fake_controller.ex
+++ b/lib/fake_controller.ex
@@ -1,65 +1,6 @@
 defmodule FakeController do
-  @moduledoc """
-  FakeControllers provide a way to respond dynamically, based on each request arrived.
+  @moduledoc false
 
-  A FakeController is a function where the name ends in `_controller`, which receives a `conn` object and returns `%FakeServer.HTTP.Response{}`.
-
-  The `conn` object has various information about the request, such as headers and query string parameters, and can be used to evaluate which response should be given.
-
-  Once you create a controller, you may create a route on a server that uses it. You can do this by calling `use_controller/1` function on `FakeServer.route/3`.
-
-  ### Where to create my controllers?
-
-  You should create your controllers in a single module that makes use of `FakeControllers.__using__/1`.
-
-  Simply import this module into the test file where the controllers will be used.
-
-  ### Examples
-  ```
-  # test/support/fake_controllers.exs
-  defmodule MyApp.FakeControllers do
-    use FakeController
-
-    def basic_controller(_conn) do
-      FakeServer.HTTP.ok(body: ~s<{"pet_name": "Rufus", "kind": "dog"}>)
-    end
-
-    def query_string_example_controller(conn) do
-      if :cowboy_req.qs_val("token", conn) |> elem(0) == "1234" do
-        FakeServer.HTTP.Response.ok
-      else
-        FakeServer.HTTP.Response.unauthorized
-      end
-    end
-  end
-
-  # test/my_app/dummy_controller_test.exs
-  defmodule MyApp.DummyControllerTest do
-    Application.ensure_all_started(:fake_server)
-    use ExUnit.Case, async: true
-
-    import FakeServer
-    import FakeControllers
-
-    test_with_server "always reply 200" do
-      route fake_server, "/dog", do: use_controller :example
-
-      response = HTTPoison.get! fake_server_address <> "/dog"
-      assert response.status_code == 200
-      assert response.body == ~s<{"pet_name": "Rufus", "kind": "dog"}>
-    end
-
-    test_with_server "evaluates FakeController and reply accordingly" do
-      route fake_server, "/", do: use_controller :example
-      response = HTTPoison.get! fake_server_address <> "/"
-      assert response.status_code == 401
-
-      response = HTTPoison.get! fake_server_address <> "/?token=1234"
-      assert response.status_code == 200
-    end
-  end
-  ```
-  """
   defmacro __using__(_opts) do
     quote do
       @before_compile unquote(__MODULE__)

--- a/lib/fake_server/http/handler.ex
+++ b/lib/fake_server/http/handler.ex
@@ -36,7 +36,6 @@ defmodule FakeServer.HTTP.Handler do
   defp choose_server_response(spec, path, conn) do
     case ServerSpec.response_for(spec, path) do
       %FakeServer.HTTP.Response{} = response ->
-        #TODO: Always reply 'response'
         handle_response_list(spec, path, response, [])
       [module: _, function: _] = controller ->
         handle_controller(spec, path, controller, conn)

--- a/lib/fake_server/http/handler.ex
+++ b/lib/fake_server/http/handler.ex
@@ -49,7 +49,8 @@ defmodule FakeServer.HTTP.Handler do
   end
 
   defp handle_function(spec, path, function, conn) do
-    function_output = function.(conn)
+    request = FakeServer.Request.from_cowboy_req(conn)
+    function_output = function.(request)
     case function_output do
       %FakeServer.HTTP.Response{} = response ->
         response

--- a/lib/fake_server/http/response.ex
+++ b/lib/fake_server/http/response.ex
@@ -27,22 +27,60 @@ defmodule FakeServer.HTTP.Response do
   FakeServer.HTTP.Response.new(404)
   ```
   """
-  def new(status, body \\ "", headers \\ %{}), do: %__MODULE__{code: status, body: body, headers: headers}
+  def new(status_code, body \\ "", headers \\ %{}), do: %__MODULE__{code: status_code, body: body, headers: headers}
 
-  # 2xx
+  @doc """
+  Creates a new response with status code 200
+  """
   def ok(body \\ "", headers \\ %{}), do: new(200, body, headers)
+
+  @doc """
+  Creates a new response with status code 201
+  """
   def created(body \\ "", headers \\ %{}), do: new(201, body, headers)
+
+  @doc """
+  Creates a new response with status code 202
+  """
   def accepted(body \\ "", headers \\ %{}), do: new(202, body, headers)
+
+  @doc """
+  Creates a new response with status code 203
+  """
   def non_authoritative_information(body \\ "", headers \\ %{}), do: new(203, body, headers)
+
+  @doc """
+  Creates a new response with status code 204
+  """
   def no_content(body \\ "", headers \\ %{}), do: new(204, body, headers)
+
+  @doc """
+  Creates a new response with status code 205
+  """
   def reset_content(body \\ "", headers \\ %{}), do: new(205, body, headers)
+
+  @doc """
+  Creates a new response with status code 206
+  """
   def partial_content(body \\ "", headers \\ %{}), do: new(206, body, headers)
+
+  @doc """
+  Creates a new response with status code 207
+  """
   def multi_status(body \\ "", headers \\ %{}), do: new(207, body, headers)
+
+  @doc """
+  Creates a new response with status code 208
+  """
   def already_reported(body \\ "", headers \\ %{}), do: new(208, body, headers)
+
+  @doc """
+  Creates a new response with status code 226
+  """
   def im_used(body \\ "", headers \\ %{}), do: new(226, body, headers)
 
   @doc """
-    Returns a list with all 4xx HTTP methods available
+  Returns a list with all 4xx HTTP methods available
   """
   def all_4xx do
     [
@@ -76,38 +114,144 @@ defmodule FakeServer.HTTP.Response do
     ]
   end
 
-  # 4xx
+  @doc """
+  Creates a new response with status code 400
+  """
   def bad_request(body \\ "", headers \\ %{}), do: new(400, body, headers)
+
+  @doc """
+  Creates a new response with status code 401
+  """
   def unauthorized(body \\ "", headers \\ %{}), do: new(401, body, headers)
+
+  @doc """
+  Creates a new response with status code 402
+  """
   def payment_required(body \\ "", headers \\ %{}), do: new(402, body, headers)
+
+  @doc """
+  Creates a new response with status code 403
+  """
   def forbidden(body \\ "", headers \\ %{}), do: new(403, body, headers)
+
+  @doc """
+  Creates a new response with status code 404
+  """
   def not_found(body \\ "", headers \\ %{}), do: new(404, body, headers)
+
+  @doc """
+  Creates a new response with status code 405
+  """
   def method_not_allowed(body \\ "", headers \\ %{}), do: new(405, body, headers)
+
+  @doc """
+  Creates a new response with status code 406
+  """
   def not_acceptable(body \\ "", headers \\ %{}), do: new(406, body, headers)
+
+  @doc """
+  Creates a new response with status code 407
+  """
   def proxy_authentication_required(body \\ "", headers \\ %{}), do: new(407, body, headers)
+
+  @doc """
+  Creates a new response with status code 408
+  """
   def request_timeout(body \\ "", headers \\ %{}), do: new(408, body, headers)
+
+  @doc """
+  Creates a new response with status code 409
+  """
   def conflict(body \\ "", headers \\ %{}), do: new(409, body, headers)
+
+  @doc """
+  Creates a new response with status code 410
+  """
   def gone(body \\ "", headers \\ %{}), do: new(410, body, headers)
+
+  @doc """
+  Creates a new response with status code 411
+  """
   def length_required(body \\ "", headers \\ %{}), do: new(411, body, headers)
+
+  @doc """
+  Creates a new response with status code 412
+  """
   def precondition_failed(body \\ "", headers \\ %{}), do: new(412, body, headers)
+
+  @doc """
+  Creates a new response with status code 413
+  """
   def payload_too_large(body \\ "", headers \\ %{}), do: new(413, body, headers)
+
+  @doc """
+  Creates a new response with status code 414
+  """
   def uri_too_long(body \\ "", headers \\ %{}), do: new(414, body, headers)
+
+  @doc """
+  Creates a new response with status code 415
+  """
   def unsupported_media_type(body \\ "", headers \\ %{}), do: new(415, body, headers)
+
+  @doc """
+  Creates a new response with status code 417
+  """
   def expectation_failed(body \\ "", headers \\ %{}), do: new(417, body, headers)
+
+  @doc """
+  Creates a new response with status code 418
+  """
   def im_a_teapot(body \\ "", headers \\ %{}), do: new(418, body, headers)
+
+  @doc """
+  Creates a new response with status code 421
+  """
   def misdirected_request(body \\ "", headers \\ %{}), do: new(421, body, headers)
+
+  @doc """
+  Creates a new response with status code 422
+  """
   def unprocessable_entity(body \\ "", headers \\ %{}), do: new(422, body, headers)
+
+  @doc """
+  Creates a new response with status code 423
+  """
   def locked(body \\ "", headers \\ %{}), do: new(423, body, headers)
+
+  @doc """
+  Creates a new response with status code 424
+  """
   def failed_dependency(body \\ "", headers \\ %{}), do: new(424, body, headers)
+
+  @doc """
+  Creates a new response with status code 426
+  """
   def upgrade_required(body \\ "", headers \\ %{}), do: new(426, body, headers)
+
+  @doc """
+  Creates a new response with status code 428
+  """
   def precondition_required(body \\ "", headers \\ %{}), do: new(428, body, headers)
+
+  @doc """
+  Creates a new response with status code 429
+  """
   def too_many_requests(body \\ "", headers \\ %{}), do: new(429, body, headers)
+
+  @doc """
+  Creates a new response with status code 431
+  """
   def request_header_fields_too_large(body \\ "", headers \\ %{}), do: new(431, body, headers)
+
+  @doc """
+  Creates a new response with status code 451
+  """
   def unavailable_for_legal_reasons(body \\ "", headers \\ %{}), do: new(451, body, headers)
 
 
   @doc """
-    Returns a list with all 4xx HTTP methods available
+  Returns a list with all 5xx HTTP methods available
   """
   def all_5xx do
     [
@@ -125,19 +269,64 @@ defmodule FakeServer.HTTP.Response do
     ]
   end
 
-  # 5xx
+  @doc """
+  Creates a new response with status code 500
+  """
   def internal_server_error(body \\ "", headers \\ %{}), do: new(500, body, headers)
+
+  @doc """
+  Creates a new response with status code 501
+  """
   def not_implemented(body \\ "", headers \\ %{}), do: new(501, body, headers)
+
+  @doc """
+  Creates a new response with status code 502
+  """
   def bad_gateway(body \\ "", headers \\ %{}), do: new(502, body, headers)
+
+  @doc """
+  Creates a new response with status code 503
+  """
   def service_unavailable(body \\ "", headers \\ %{}), do: new(503, body, headers)
+
+  @doc """
+  Creates a new response with status code 504
+  """
   def gateway_timeout(body \\ "", headers \\ %{}), do: new(504, body, headers)
+
+  @doc """
+  Creates a new response with status code 505
+  """
   def http_version_not_supported(body \\ "", headers \\ %{}), do: new(505, body, headers)
+
+  @doc """
+  Creates a new response with status code 506
+  """
   def variant_also_negotiates(body \\ "", headers \\ %{}), do: new(506, body, headers)
+
+  @doc """
+  Creates a new response with status code 507
+  """
   def insufficient_storage(body \\ "", headers \\ %{}), do: new(507, body, headers)
+
+  @doc """
+  Creates a new response with status code 508
+  """
   def loop_detected(body \\ "", headers \\ %{}), do: new(508, body, headers)
+
+  @doc """
+  Creates a new response with status code 510
+  """
   def not_extended(body \\ "", headers \\ %{}), do: new(510, body, headers)
+
+  @doc """
+  Creates a new response with status code 511
+  """
   def network_authentication_required(body \\ "", headers \\ %{}), do: new(511, body, headers)
 
+  @doc """
+  FakeServer default response. Used when there are no responses left to reply.
+  """
   def default, do: new(200, ~s<{"message": "This is a default response from FakeServer"}>)
 end
 

--- a/lib/fake_server/http/response.ex
+++ b/lib/fake_server/http/response.ex
@@ -41,6 +41,41 @@ defmodule FakeServer.HTTP.Response do
   def already_reported(body \\ "", headers \\ %{}), do: new(208, body, headers)
   def im_used(body \\ "", headers \\ %{}), do: new(226, body, headers)
 
+  @doc """
+    Returns a list with all 4xx HTTP methods available
+  """
+  def all_4xx do
+    [
+      bad_request(),
+      unauthorized(),
+      payment_required(),
+      forbidden(),
+      not_found(),
+      method_not_allowed(),
+      not_acceptable(),
+      proxy_authentication_required(),
+      request_timeout(),
+      conflict(),
+      gone(),
+      length_required(),
+      precondition_failed(),
+      payload_too_large(),
+      uri_too_long(),
+      unsupported_media_type(),
+      expectation_failed(),
+      im_a_teapot(),
+      misdirected_request(),
+      unprocessable_entity(),
+      locked(),
+      failed_dependency(),
+      upgrade_required(),
+      precondition_required(),
+      too_many_requests(),
+      request_header_fields_too_large(),
+      unavailable_for_legal_reasons()
+    ]
+  end
+
   # 4xx
   def bad_request(body \\ "", headers \\ %{}), do: new(400, body, headers)
   def unauthorized(body \\ "", headers \\ %{}), do: new(401, body, headers)
@@ -69,6 +104,26 @@ defmodule FakeServer.HTTP.Response do
   def too_many_requests(body \\ "", headers \\ %{}), do: new(429, body, headers)
   def request_header_fields_too_large(body \\ "", headers \\ %{}), do: new(431, body, headers)
   def unavailable_for_legal_reasons(body \\ "", headers \\ %{}), do: new(451, body, headers)
+
+
+  @doc """
+    Returns a list with all 4xx HTTP methods available
+  """
+  def all_5xx do
+    [
+      internal_server_error(),
+      not_implemented(),
+      bad_gateway(),
+      service_unavailable(),
+      gateway_timeout(),
+      http_version_not_supported(),
+      variant_also_negotiates(),
+      insufficient_storage(),
+      loop_detected(),
+      not_extended(),
+      network_authentication_required()
+    ]
+  end
 
   # 5xx
   def internal_server_error(body \\ "", headers \\ %{}), do: new(500, body, headers)

--- a/lib/fake_server/http/server.ex
+++ b/lib/fake_server/http/server.ex
@@ -22,22 +22,6 @@ defmodule FakeServer.HTTP.Server do
     |> ServerAgent.save_spec
   end
 
-  def add_route(server_id, path, response_list \\ []) do
-    spec = ServerAgent.get_spec(server_id)
-    spec
-    |> ServerSpec.configure_response_list_for(path, response_list)
-    |> update_router
-    |> ServerAgent.save_spec
-  end
-
-  def add_controller(server_id, path, [module: _, function: _] = controller) do
-    spec = ServerAgent.get_spec(server_id)
-    spec
-    |> ServerSpec.configure_controller_for(path, controller)
-    |> update_router
-    |> ServerAgent.save_spec
-  end
-
   def set_default_response(server_id, %Response{} = default_response) do
     spec = ServerAgent.get_spec(server_id)
     spec

--- a/lib/fake_server/http/server.ex
+++ b/lib/fake_server/http/server.ex
@@ -14,6 +14,14 @@ defmodule FakeServer.HTTP.Server do
     {:ok, server_spec.id, server_spec.port}
   end
 
+  def add_response(server_id, path, response) do
+    spec = ServerAgent.get_spec(server_id)
+    spec
+    |> ServerSpec.configure_response_for(path, response)
+    |> update_router
+    |> ServerAgent.save_spec
+  end
+
   def add_route(server_id, path, response_list \\ []) do
     spec = ServerAgent.get_spec(server_id)
     spec

--- a/lib/fake_server/request.ex
+++ b/lib/fake_server/request.ex
@@ -1,5 +1,17 @@
 defmodule FakeServer.Request do
-  @moduledoc false
+  @moduledoc """
+  Stores some information about a request when it arrives the server.
+
+  ## Structure Fields:
+
+    - `method`: a string with the HTTP request method.
+    - `body`: a string with the body of the request.
+    - `headers`: a map with the request headers.
+    - `path`: a string with the request path.
+    - `cookies`: a map with the request cookies.
+    - `query_string`: a string with the query_string.
+    - `query`: a map with each one of the parameters from the query string.
+  """
   defstruct [
     method: "",
     body: "",
@@ -10,6 +22,7 @@ defmodule FakeServer.Request do
     query: %{}
   ]
 
+  @doc false
   def from_cowboy_req(cowboy_req) do
     %__MODULE__{
       method: method(cowboy_req),

--- a/lib/fake_server/request.ex
+++ b/lib/fake_server/request.ex
@@ -1,4 +1,5 @@
 defmodule FakeServer.Request do
+  @moduledoc false
   defstruct [
     method: "",
     body: "",
@@ -52,7 +53,9 @@ defmodule FakeServer.Request do
   end
 
   defp query(cowboy_req) do
-    query_string(cowboy_req)
+    qs = query_string(cowboy_req)
+
+    qs
     |> String.split("&")
     |> create_query_map
   end
@@ -60,7 +63,7 @@ defmodule FakeServer.Request do
   defp create_query_map([""]), do: %{}
   defp create_query_map(query_list) do
     query_list
-    |> Enum.map(fn(query) -> String.split(query, "=") |> List.to_tuple end)
+    |> Enum.map(fn(query) -> List.to_tuple(String.split(query, "=")) end)
     |> Enum.into(%{})
   end
 end

--- a/lib/fake_server/request.ex
+++ b/lib/fake_server/request.ex
@@ -1,0 +1,66 @@
+defmodule FakeServer.Request do
+  defstruct [
+    method: "",
+    body: "",
+    headers: %{},
+    path: "",
+    cookies: %{},
+    query_string: "",
+    query: %{}
+  ]
+
+  def from_cowboy_req(cowboy_req) do
+    %__MODULE__{
+      method: method(cowboy_req),
+      body: body(cowboy_req),
+      headers: headers(cowboy_req),
+      path: path(cowboy_req),
+      query_string: query_string(cowboy_req),
+      query: query(cowboy_req)
+    }
+  end
+
+  defp method(cowboy_req) do
+    cowboy_req
+    |> :cowboy_req.method
+    |> elem(0)
+  end
+
+  defp body(cowboy_req) do
+    cowboy_req
+    |> :cowboy_req.body
+    |> elem(1)
+  end
+
+  defp headers(cowboy_req) do
+    cowboy_req
+    |> :cowboy_req.headers
+    |> elem(0)
+    |> Enum.into(%{})
+  end
+
+  defp path(cowboy_req) do
+    cowboy_req
+    |> :cowboy_req.path
+    |> elem(0)
+  end
+
+  defp query_string(cowboy_req) do
+    cowboy_req
+    |> :cowboy_req.qs
+    |> elem(0)
+  end
+
+  defp query(cowboy_req) do
+    query_string(cowboy_req)
+    |> String.split("&")
+    |> create_query_map
+  end
+
+  defp create_query_map([""]), do: %{}
+  defp create_query_map(query_list) do
+    query_list
+    |> Enum.map(fn(query) -> String.split(query, "=") |> List.to_tuple end)
+    |> Enum.into(%{})
+  end
+end

--- a/lib/fake_server/specs/path_spec.ex
+++ b/lib/fake_server/specs/path_spec.ex
@@ -1,7 +1,7 @@
 defmodule FakeServer.Specs.PathSpec do
   @moduledoc false
 
-  defstruct [controller: nil, response_list: [], hits: 0]
+  defstruct [controller: nil, response_list: [], hits: 0, response: nil]
 
   alias FakeServer.Specs.PathSpec
 
@@ -11,6 +11,14 @@ defmodule FakeServer.Specs.PathSpec do
 
   def response_list(%PathSpec{} = spec) do
     spec.response_list
+  end
+
+  def response(%PathSpec{} = spec) do
+    spec.response
+  end
+
+  def configure_response(%PathSpec{} = spec, new_response) do
+    %PathSpec{spec | response: new_response}
   end
 
   def configure_response_list(%PathSpec{} = spec, new_response_list) do

--- a/lib/fake_server/specs/path_spec.ex
+++ b/lib/fake_server/specs/path_spec.ex
@@ -1,16 +1,12 @@
 defmodule FakeServer.Specs.PathSpec do
   @moduledoc false
 
-  defstruct [controller: nil, response_list: [], hits: 0, response: nil]
+  defstruct [hits: 0, response: nil]
 
   alias FakeServer.Specs.PathSpec
 
   def new do
     %PathSpec{}
-  end
-
-  def response_list(%PathSpec{} = spec) do
-    spec.response_list
   end
 
   def response(%PathSpec{} = spec) do
@@ -19,17 +15,5 @@ defmodule FakeServer.Specs.PathSpec do
 
   def configure_response(%PathSpec{} = spec, new_response) do
     %PathSpec{spec | response: new_response}
-  end
-
-  def configure_response_list(%PathSpec{} = spec, new_response_list) do
-    %PathSpec{spec | response_list: new_response_list}
-  end
-
-  def controller(%PathSpec{} = spec) do
-    spec.controller
-  end
-
-  def configure_controller(%PathSpec{} = spec, new_controller) do
-    %PathSpec{spec | controller: new_controller}
   end
 end

--- a/lib/fake_server/specs/server_spec.ex
+++ b/lib/fake_server/specs/server_spec.ex
@@ -32,6 +32,19 @@ defmodule FakeServer.Specs.ServerSpec do
     end
   end
 
+  def response_for(%ServerSpec{} = spec, path) do
+    case spec.paths[path] do
+      nil -> nil
+      path_spec -> PathSpec.response(path_spec)
+    end
+  end
+
+  def configure_response_for(%ServerSpec{} = spec, path, new_response) do
+    path_spec = (spec.paths[path] || PathSpec.new) |> PathSpec.configure_response(new_response)
+    new_path_list = Map.put(spec.paths, path, path_spec)
+    %ServerSpec{spec | paths: new_path_list}
+  end
+
   def configure_response_list_for(%ServerSpec{} = spec, path, new_response_list) do
     new_response_list = List.wrap(new_response_list)
     path_spec = (spec.paths[path] || PathSpec.new) |> PathSpec.configure_response_list(new_response_list)

--- a/lib/fake_server/specs/server_spec.ex
+++ b/lib/fake_server/specs/server_spec.ex
@@ -1,7 +1,7 @@
 defmodule FakeServer.Specs.ServerSpec do
   @moduledoc false
 
-  defstruct [id: nil, paths: %{}, controllers: %{}, default_response: FakeServer.HTTP.Response.default, port: nil]
+  defstruct [id: nil, paths: %{}, default_response: FakeServer.HTTP.Response.default, port: nil]
   @enforce_keys[:name]
 
   @id_length 16
@@ -25,13 +25,6 @@ defmodule FakeServer.Specs.ServerSpec do
     Map.keys(spec.paths)
   end
 
-  def response_list_for(%ServerSpec{} = spec, path) do
-    case spec.paths[path] do
-      nil -> nil
-      path_spec -> PathSpec.response_list(path_spec)
-    end
-  end
-
   def response_for(%ServerSpec{} = spec, path) do
     case spec.paths[path] do
       nil -> nil
@@ -45,32 +38,12 @@ defmodule FakeServer.Specs.ServerSpec do
     %ServerSpec{spec | paths: new_path_list}
   end
 
-  def configure_response_list_for(%ServerSpec{} = spec, path, new_response_list) do
-    new_response_list = List.wrap(new_response_list)
-    path_spec = (spec.paths[path] || PathSpec.new) |> PathSpec.configure_response_list(new_response_list)
-    new_path_list = Map.put(spec.paths, path, path_spec)
-    %ServerSpec{spec | paths: new_path_list}
-  end
-
-  def controller_for(%ServerSpec{} = spec, path) do
-    case spec.paths[path] do
-      nil -> nil
-      path_spec -> PathSpec.controller(path_spec)
-    end
-  end
-
-  def configure_controller_for(%ServerSpec{} = spec, path, [module: _, function: _] = new_controller) do
-    path_spec = (spec.paths[path] || PathSpec.new) |> PathSpec.configure_controller(new_controller)
-    new_path_list = Map.put(spec.paths, path, path_spec)
-    %ServerSpec{spec | paths: new_path_list}
-  end
-
   def default_response(%ServerSpec{} = spec) do
     spec.default_response
   end
 
   def configure_default_response(%ServerSpec{} = spec, new_default_response) do
-    spec = configure_response_list_for(spec, :_, [])
+    spec = configure_response_for(spec, :_, [])
     %ServerSpec{spec | default_response: new_default_response}
   end
 

--- a/test/fake_server/http/response_test.exs
+++ b/test/fake_server/http/response_test.exs
@@ -66,6 +66,13 @@ defmodule ResponseTest do
   end
 
   describe "4XX" do
+    test "all_4xx responds a list with all 4xx status code" do
+      assert length(Response.all_4xx) == 27
+      Enum.each(Response.all_4xx, fn(response) ->
+        assert response.code >= 400 && response.code <= 451
+      end)
+    end
+
     test "returns the correspondent status code with a map as response body" do
       assert Response.bad_request(%{status_kind: "4xx"})== %Response{code: 400, body: %{status_kind: "4xx"}, headers: %{}}
       assert Response.unauthorized(%{status_kind: "4xx"})== %Response{code: 401, body: %{status_kind: "4xx"}, headers: %{}}
@@ -127,17 +134,26 @@ defmodule ResponseTest do
     end
   end
 
-  test "5xx" do
-    assert Response.internal_server_error ==  %Response{code: 500, body: "", headers: %{}}
-    assert Response.not_implemented ==  %Response{code: 501, body: "", headers: %{}}
-    assert Response.bad_gateway ==  %Response{code: 502, body: "", headers: %{}}
-    assert Response.service_unavailable ==  %Response{code: 503, body: "", headers: %{}}
-    assert Response.gateway_timeout ==  %Response{code: 504, body: "", headers: %{}}
-    assert Response.http_version_not_supported ==  %Response{code: 505, body: "", headers: %{}}
-    assert Response.variant_also_negotiates ==  %Response{code: 506, body: "", headers: %{}}
-    assert Response.insufficient_storage ==  %Response{code: 507, body: "", headers: %{}}
-    assert Response.loop_detected ==  %Response{code: 508, body: "", headers: %{}}
-    assert Response.not_extended ==  %Response{code: 510, body: "", headers: %{}}
-    assert Response.network_authentication_required ==  %Response{code: 511, body: "", headers: %{}}
+  describe "5xx" do
+    test "all_5xx responds a list with all 5xx status code" do
+      assert length(Response.all_5xx) == 11
+      Enum.each(Response.all_5xx, fn(response) ->
+        assert response.code >= 500 && response.code <= 511
+      end)
+    end
+
+    test "5xx" do
+      assert Response.internal_server_error ==  %Response{code: 500, body: "", headers: %{}}
+      assert Response.not_implemented ==  %Response{code: 501, body: "", headers: %{}}
+      assert Response.bad_gateway ==  %Response{code: 502, body: "", headers: %{}}
+      assert Response.service_unavailable ==  %Response{code: 503, body: "", headers: %{}}
+      assert Response.gateway_timeout ==  %Response{code: 504, body: "", headers: %{}}
+      assert Response.http_version_not_supported ==  %Response{code: 505, body: "", headers: %{}}
+      assert Response.variant_also_negotiates ==  %Response{code: 506, body: "", headers: %{}}
+      assert Response.insufficient_storage ==  %Response{code: 507, body: "", headers: %{}}
+      assert Response.loop_detected ==  %Response{code: 508, body: "", headers: %{}}
+      assert Response.not_extended ==  %Response{code: 510, body: "", headers: %{}}
+      assert Response.network_authentication_required ==  %Response{code: 511, body: "", headers: %{}}
+    end
   end
 end

--- a/test/fake_server/http/server_integration_test.exs
+++ b/test/fake_server/http/server_integration_test.exs
@@ -10,8 +10,8 @@ defmodule FakeServer.HTTP.ServerTest do
     Response.bad_request
   end
 
-  def with_conn_controller(conn) do
-    case :cowboy_req.qs_val("respond_with", conn) |> elem(0) do
+  def with_request_controller(req) do
+    case req.query["respond_with"] do
       "404" -> Response.not_found
       "401" -> Response.unauthorized
       "400" -> Response.bad_request
@@ -92,7 +92,7 @@ defmodule FakeServer.HTTP.ServerTest do
     test "server will check conn variable on controller function to check what to reply" do
       {:ok, server_name, port} = Server.run
 
-      Server.add_response(server_name, "/test", [module: __MODULE__, function: :with_conn_controller])
+      Server.add_response(server_name, "/test", [module: __MODULE__, function: :with_request_controller])
 
       {:ok, response} = :httpc.request(:get, {'http://127.0.0.1:#{port}/test?respond_with=404', [{'connection', 'close'}]}, [], [])
       assert response |> elem(0) |> elem(1) == 404

--- a/test/fake_server/request_test.exs
+++ b/test/fake_server/request_test.exs
@@ -1,0 +1,39 @@
+defmodule FakeServer.RequestTest do
+  use ExUnit.Case
+
+  @cowboy_req {
+    :http_req, :some_port, :ranch_tcp, :keepalive, :some_pid, "POST",
+    :"HTTP/1.1", {{127, 0, 0, 1}, 52683}, "127.0.0.1", :undefined, 6455,
+    "/", :undefined, "a=b", :undefined, [],
+    [{"host", "127.0.0.1:6455"}, {"user-agent", "hackney/1.10.1"}, {"content-type", "application/octet-stream"}, {"content-length", "14"}],
+    [], :undefined, [], :waiting, "{\"test\": true}",
+    :undefined, false, :waiting, [], "", :undefined
+  }
+
+  describe "#from_cowboy_req" do
+    test "creates a struct with the http method of cowboy_req object" do
+      request = FakeServer.Request.from_cowboy_req(@cowboy_req)
+      assert request.method == "POST"
+    end
+
+    test "creates a struct with the http body of cowboy_req object" do
+      request = FakeServer.Request.from_cowboy_req(@cowboy_req)
+      assert request.body == "{\"test\": true}"
+    end
+
+    test "creates a struct with the http headers of cowboy_req object" do
+      request = FakeServer.Request.from_cowboy_req(@cowboy_req)
+      assert request.headers == %{"user-agent" => "hackney/1.10.1", "host" => "127.0.0.1:6455", "content-length" => "14", "content-type" => "application/octet-stream"}
+    end
+
+    test "creates a struct with the http query_string of cowboy_req object" do
+      request = FakeServer.Request.from_cowboy_req(@cowboy_req)
+      assert request.query_string == "a=b"
+    end
+
+    test "creates a struct with the http query of cowboy_req object" do
+      request = FakeServer.Request.from_cowboy_req(@cowboy_req)
+      assert request.query == %{"a" => "b"}
+    end
+  end
+end

--- a/test/fake_server/specs/path_spec_test.exs
+++ b/test/fake_server/specs/path_spec_test.exs
@@ -10,36 +10,24 @@ defmodule FakeServer.Specs.PathSpecTest do
     end
   end
 
-  describe "#response_list" do
+  describe "#response" do
     test "returns a response list for a path" do
-      spec = PathSpec.new |> PathSpec.configure_response_list([Response.ok])
-      assert PathSpec.response_list(spec) == [Response.ok]
+      spec = PathSpec.new |> PathSpec.configure_response([Response.ok])
+      assert PathSpec.response(spec) == [Response.ok]
     end
 
     test "returns [] if response list not set" do
       spec = PathSpec.new
-      assert PathSpec.response_list(spec) == []
+      assert PathSpec.response(spec) == nil
     end
   end
 
-  describe "#configure_response_list" do
+  describe "#configure_response" do
     test "sets response list for a path" do
       spec = PathSpec.new
-      assert PathSpec.response_list(spec) == []
-      spec = PathSpec.new |> PathSpec.configure_response_list([Response.ok])
-      assert PathSpec.response_list(spec) == [Response.ok]
-    end
-  end
-
-  describe "#controller" do
-    test "returns a controller for a path" do
-      spec = PathSpec.new |> PathSpec.configure_controller([module: SomeModule, function: :some_function])
-      assert PathSpec.controller(spec) == [module: SomeModule, function: :some_function]
-    end
-
-    test "returns [] if response list not set" do
-      spec = PathSpec.new
-      assert PathSpec.controller(spec) == nil
+      assert PathSpec.response(spec) == nil
+      spec = PathSpec.new |> PathSpec.configure_response([Response.ok])
+      assert PathSpec.response(spec) == [Response.ok]
     end
   end
 end

--- a/test/fake_server/specs/server_spec_test.exs
+++ b/test/fake_server/specs/server_spec_test.exs
@@ -51,78 +51,36 @@ defmodule FakeServer.Specs.ServerSpecTest do
     end
   end
 
-  describe "#response_list_for" do
+  describe "#response_for" do
     test "returns nil when path does not exists on spec" do
       assert ServerSpec.new
-      |> ServerSpec.response_list_for("/path") == nil
+      |> ServerSpec.response_for("/path") == nil
     end
 
     test "returns [] when path exists but list is empty" do
-      spec = ServerSpec.new |> ServerSpec.configure_response_list_for("/path", [])
-      assert ServerSpec.response_list_for(spec, "/path") == []
+      spec = ServerSpec.new |> ServerSpec.configure_response_for("/path", [])
+      assert ServerSpec.response_for(spec, "/path") == []
     end
 
     test "returns a list when path exists and list is not empty" do
-      spec = ServerSpec.new |> ServerSpec.configure_response_list_for("/path", [FakeServer.HTTP.Response.ok])
-      assert ServerSpec.response_list_for(spec, "/path") == [FakeServer.HTTP.Response.ok]
+      spec = ServerSpec.new |> ServerSpec.configure_response_for("/path", [FakeServer.HTTP.Response.ok])
+      assert ServerSpec.response_for(spec, "/path") == [FakeServer.HTTP.Response.ok]
     end
   end
 
   describe "#configure_response_list" do
     test "saves an empty list to path on a server" do
       spec = ServerSpec.new
-      assert ServerSpec.response_list_for(spec, "/path") == nil
-      spec = ServerSpec.configure_response_list_for(spec, "/path", [])
-      assert ServerSpec.response_list_for(spec, "/path") == []
+      assert ServerSpec.response_for(spec, "/path") == nil
+      spec = ServerSpec.configure_response_for(spec, "/path", [])
+      assert ServerSpec.response_for(spec, "/path") == []
     end
 
     test "saves a list to path on a server" do
       spec = ServerSpec.new
-      assert ServerSpec.response_list_for(spec, "/path") == nil
-      spec = ServerSpec.configure_response_list_for(spec, "/path", [FakeServer.HTTP.Response.ok])
-      assert ServerSpec.response_list_for(spec, "/path") == [FakeServer.HTTP.Response.ok]
-    end
-
-    test "saves a single element as a list to path on a server" do
-      spec = ServerSpec.new
-      assert ServerSpec.response_list_for(spec, "/path") == nil
-      spec = ServerSpec.configure_response_list_for(spec, "/path", FakeServer.HTTP.Response.ok)
-      assert ServerSpec.response_list_for(spec, "/path") == [FakeServer.HTTP.Response.ok]
-    end
-  end
-
-  describe "#controller_for" do
-    test "returns nil when path does not exists on spec" do
-      assert ServerSpec.new
-      |> ServerSpec.controller_for("/path") == nil
-    end
-
-    test "returns nil if path is configured without a controller" do
-      spec = ServerSpec.new |> ServerSpec.configure_response_list_for("/path", FakeServer.HTTP.Response.ok)
-      assert ServerSpec.controller_for(spec, "/path") == nil
-    end
-
-    test "returns a list when path exists and list is not empty" do
-      spec = ServerSpec.new |> ServerSpec.configure_controller_for("/path", [module: SomeController, function: :some_function])
-      assert ServerSpec.controller_for(spec, "/path") == [module: SomeController, function: :some_function]
-    end
-  end
-
-  describe "#configure_controller_for" do
-    test "saves a controller to path" do
-      spec = ServerSpec.new
-      assert ServerSpec.controller_for(spec, "/path") == nil
-      spec = ServerSpec.configure_controller_for(spec, "/path", [module: SomeController, function: :some_function])
-      assert ServerSpec.controller_for(spec, "/path") == [module: SomeController, function: :some_function]
-    end
-
-    test "overwrites a controller if one already exist" do
-      spec = ServerSpec.new
-      spec = ServerSpec.configure_controller_for(spec, "/path", [module: SomeController, function: :some_function])
-      assert ServerSpec.controller_for(spec, "/path") == [module: SomeController, function: :some_function]
-
-      spec = ServerSpec.configure_controller_for(spec, "/path", [module: AnotherController, function: :another_function])
-      assert ServerSpec.controller_for(spec, "/path") == [module: AnotherController, function: :another_function]
+      assert ServerSpec.response_for(spec, "/path") == nil
+      spec = ServerSpec.configure_response_for(spec, "/path", [FakeServer.HTTP.Response.ok])
+      assert ServerSpec.response_for(spec, "/path") == [FakeServer.HTTP.Response.ok]
     end
   end
 

--- a/test/integration/fake_server_integration_test.exs
+++ b/test/integration/fake_server_integration_test.exs
@@ -115,6 +115,14 @@ defmodule FakeServer.FakeServerIntegrationTest do
     assert response.body == ~s<{"message": "This is a default response from FakeServer"}>
   end
 
+  test_with_server "returns default_response if no response is configured to the given route" do
+    route "/"
+
+    response = HTTPoison.get! FakeServer.address <> "/"
+    assert response.status_code == 200
+    assert response.body == ~s<{"message": "This is a default response from FakeServer"}>
+  end
+
   test_with_server "accepts a single element instead of a list" do
     route "/test", Response.bad_request
 

--- a/test/integration/fake_server_integration_test.exs
+++ b/test/integration/fake_server_integration_test.exs
@@ -27,18 +27,18 @@ defmodule FakeServer.FakeServerIntegrationTest do
 
   test_with_server "stores the routes in test env" do
     assert FakeServer.env.routes == []
-    route "/", do: []
+    route "/", []
     assert FakeServer.env.routes == ["/"]
 
-    route "/route1", do: Response.bad_request
+    route "/route1", Response.bad_request
     assert FakeServer.env.routes == ["/route1", "/"]
 
-    route "/route2", do: use_controller :query_string
+    route "/route2", use_controller :query_string
     assert FakeServer.env.routes == ["/route2", "/route1", "/"]
   end
 
   test_with_server "save server hits in the environment" do
-    route "/", do: Response.ok
+    route "/", Response.ok
     assert FakeServer.hits == 0
     HTTPoison.get! FakeServer.address <> "/"
     assert FakeServer.hits == 1
@@ -47,7 +47,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "default response can be configured and will be replied response list is empty", [port: 5001, default_response: Response.bad_request] do
-    route "/", do: []
+    route "/", []
     assert FakeServer.hits == 0
     response = HTTPoison.get! FakeServer.address <> "/"
     assert response.status_code == 400
@@ -55,7 +55,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "default response can be configured and will be replied with a single response", [default_response: Response.forbidden] do
-    route "/test", do: Response.bad_request
+    route "/test", Response.bad_request
 
     response = HTTPoison.get! FakeServer.address <> "/test"
     assert response.status_code == 400
@@ -65,7 +65,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "default response will be replied if server is configured with an empty list", [default_response: Response.forbidden] do
-    route "/test", do: []
+    route "/test", []
 
     response = HTTPoison.get! FakeServer.address <> "/test"
     assert response.status_code == 403
@@ -84,7 +84,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "reply the first element of the list and remove it" do
-    route "/test", do: [Response.ok, Response.not_found, Response.bad_request]
+    route "/test", [Response.ok, Response.not_found, Response.bad_request]
 
     response = HTTPoison.get! FakeServer.address <> "/test"
     assert response.status_code == 200
@@ -101,7 +101,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "always reply the default_response when the list empties" do
-    route "/test", do: [Response.bad_request]
+    route "/test", [Response.bad_request]
 
     response = HTTPoison.get! FakeServer.address <> "/test"
     assert response.status_code == 400
@@ -116,7 +116,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "accepts a single element instead of a list" do
-    route "/test", do: Response.bad_request
+    route "/test", Response.bad_request
 
     response = HTTPoison.get! FakeServer.address <> "/test"
     assert response.status_code == 400
@@ -127,7 +127,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "reply the expected response on cofigured route and 404 on not configured routes" do
-    route "/", do: [Response.bad_request]
+    route "/", [Response.bad_request]
     response = HTTPoison.get! FakeServer.address <> "/"
     assert response.status_code == 400
 
@@ -139,7 +139,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "reply the expected response on cofigured route and 404 on not configured routes with a single element" do
-    route "/", do: Response.bad_request
+    route "/", Response.bad_request
     response = HTTPoison.get! FakeServer.address <> "/"
     assert response.status_code == 400
 
@@ -151,7 +151,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "with a simple controller always reply 200" do
-    route "/dog", do: use_controller :single_response
+    route "/dog", use_controller :single_response
 
     response = HTTPoison.get! FakeServer.address <> "/dog"
     assert response.status_code == 200
@@ -159,7 +159,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "evaluates FakeController and reply accordingly" do
-    route "/", do: use_controller :query_string
+    route "/", use_controller :query_string
     response = HTTPoison.get! FakeServer.address <> "/"
     assert response.status_code == 401
 
@@ -168,9 +168,9 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "accepts controllers, response lists and single responses on different routes" do
-    route "/controller", do: use_controller :query_string
-    route "/list", do: [Response.ok, Response.not_found, Response.bad_request]
-    route "/response", do: Response.bad_request
+    route "/controller", use_controller :query_string
+    route "/list", [Response.ok, Response.not_found, Response.bad_request]
+    route "/response", Response.bad_request
 
     response = HTTPoison.get! FakeServer.address <> "/controller"
     assert response.status_code == 401
@@ -195,35 +195,35 @@ defmodule FakeServer.FakeServerIntegrationTest do
   end
 
   test_with_server "works with response headers as a keyword list" do
-    route "/", do: Response.ok(~s<{"response": "ok"}>, [{'Content-Type', 'application/json'}])
+    route "/", Response.ok(~s<{"response": "ok"}>, [{'Content-Type', 'application/json'}])
 
     response = HTTPoison.get! FakeServer.address <> "/"
     assert Enum.any?(response.headers, fn(header) -> header == {"Content-Type", "application/json"} end)
   end
 
   test_with_server "works with response headers as map" do
-    route "/", do: Response.ok(~s<{"response": "ok"}>, %{'Content-Type' => 'application/json'})
+    route "/", Response.ok(~s<{"response": "ok"}>, %{'Content-Type' => 'application/json'})
 
     response = HTTPoison.get! FakeServer.address <> "/"
     assert Enum.any?(response.headers, fn(header) -> header == {"Content-Type", "application/json"} end)
   end
 
   test_with_server "works with response headers as map with string keys" do
-    route "/", do: Response.ok(~s<{"response": "ok"}>, %{"Content-Type" => "application/json"})
+    route "/", Response.ok(~s<{"response": "ok"}>, %{"Content-Type" => "application/json"})
 
     response = HTTPoison.get! FakeServer.address <> "/"
     assert Enum.any?(response.headers, fn(header) -> header == {"Content-Type", "application/json"} end)
   end
 
   test_with_server "works when the response is created with a map as response body" do
-    route "/", do: Response.ok(%{response: "ok"})
+    route "/", Response.ok(%{response: "ok"})
 
     response = HTTPoison.get! FakeServer.address <> "/"
     assert response.body == ~s<{"response":"ok"}>
   end
 
   test_with_server "works when the response is created with a string as response body" do
-    route "/", do: Response.ok(~s<{"response":"ok"}>)
+    route "/", Response.ok(~s<{"response":"ok"}>)
 
     response = HTTPoison.get! FakeServer.address <> "/"
     assert response.body == ~s<{"response":"ok"}>
@@ -234,7 +234,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     test_with_server "generates a response wiht custom data" do
       customized_response = %{body: person} = FakeResponseFactory.build(:person)
 
-      route "/person", do: customized_response
+      route "/person", customized_response
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -249,8 +249,8 @@ defmodule FakeServer.FakeServerIntegrationTest do
     test_with_server "can build multiple custom response types" do
       customized_response = %{body: person} = FakeResponseFactory.build(:person)
 
-      route "/person", do: customized_response
-      route "/not_found", do: FakeResponseFactory.build(:customized_404)
+      route "/person", customized_response
+      route "/not_found", FakeResponseFactory.build(:customized_404)
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -268,7 +268,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "can set some attributes for the built response body" do
-      route "/person", do: FakeResponseFactory.build(:person, name: "John", email: "john@myawesomemail.com")
+      route "/person", FakeResponseFactory.build(:person, name: "John", email: "john@myawesomemail.com")
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -279,7 +279,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "delete attributes if the value is set to nil" do
-      route "/person", do: FakeResponseFactory.build(:person, email: nil)
+      route "/person", FakeResponseFactory.build(:person, email: nil)
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -289,7 +289,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "can set and delete attributes at the same built call" do
-      route "/person", do: FakeResponseFactory.build(:person, name: "John", email: nil)
+      route "/person", FakeResponseFactory.build(:person, name: "John", email: nil)
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -300,7 +300,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "can set attributes as map" do
-      route "/person", do: FakeResponseFactory.build(:person, company: %{name: "MyCompany Inc.", country: "Brazil"})
+      route "/person", FakeResponseFactory.build(:person, company: %{name: "MyCompany Inc.", country: "Brazil"})
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -311,7 +311,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "can delete map attributes" do
-      route "/person", do: FakeResponseFactory.build(:person, company: nil)
+      route "/person", FakeResponseFactory.build(:person, company: nil)
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -321,7 +321,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "do not add an attribute if it does not exist at default response" do
-      route "/person", do: FakeResponseFactory.build(:person, pet: "Rufus")
+      route "/person", FakeResponseFactory.build(:person, pet: "Rufus")
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -331,7 +331,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     end
 
     test_with_server "can set custom response headers" do
-      route "/person", do: FakeResponseFactory.build(:person, %{"Content-Type" => "application/x-www-form-urlencoded"})
+      route "/person", FakeResponseFactory.build(:person, %{"Content-Type" => "application/x-www-form-urlencoded"})
 
       response = HTTPoison.get! FakeServer.address <> "/person"
 
@@ -341,7 +341,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
 
     test_with_server "can set body and headers at the same time" do
       custom_response = FakeResponseFactory.build(:person, [name: "John"], %{"Content-Type" => "application/x-www-form-urlencoded"})
-      route "/person", do: custom_response
+      route "/person", custom_response
 
       response = HTTPoison.get! FakeServer.address <> "/person"
       body = Poison.decode!(response.body)
@@ -353,7 +353,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
 
     test_with_server "add a new header even if it does not exist on custom response" do
       custom_response = FakeResponseFactory.build(:person, %{"X-MY-HEADER" => "Hi!"})
-      route "/person", do: custom_response
+      route "/person", custom_response
 
       response = HTTPoison.get! FakeServer.address <> "/person"
 
@@ -364,7 +364,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
 
     test_with_server "delete a header if it's value is nil" do
       custom_response = FakeResponseFactory.build(:person, %{"Content-Type" => nil})
-      route "/person", do: custom_response
+      route "/person", custom_response
 
       response = HTTPoison.get! FakeServer.address <> "/person"
 
@@ -375,7 +375,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
     test_with_server "create a list of responses" do
       person_list = FakeResponseFactory.build_list(3, :person)
 
-      route "/person", do: person_list
+      route "/person", person_list
 
       Enum.each(person_list, fn(person) ->
         response = HTTPoison.get! FakeServer.address <> "/person"
@@ -387,6 +387,58 @@ defmodule FakeServer.FakeServerIntegrationTest do
         assert person.body[:company][:name] == body["company"]["name"]
         assert person.body[:company][:country] == body["company"]["country"]
       end)
+    end
+  end
+
+  describe "when using functions" do
+    test_with_server "reply with the function return if it's a valid Response struct" do
+      route "/", fn(_) -> Response.ok end
+
+      response = HTTPoison.get! FakeServer.address <> "/"
+      assert response.status_code == 200
+    end
+
+    test_with_server "reply with the function return if it's a valid Response struct list" do
+      route "/", fn(_) -> [Response.ok, Response.not_found] end
+
+      response = HTTPoison.get! FakeServer.address <> "/"
+      assert response.status_code == 200
+      response = HTTPoison.get! FakeServer.address <> "/"
+      assert response.status_code == 404
+    end
+
+    test_with_server "reply with the function return if it's a valid Response struct from a factory" do
+      route "/", fn(_) -> FakeResponseFactory.build(:person) end
+
+      response1 = HTTPoison.get! FakeServer.address <> "/"
+      assert response1.status_code == 200
+      response2 = HTTPoison.get! FakeServer.address <> "/"
+      assert response2.status_code == 200
+      assert response1 != response2
+    end
+
+    test_with_server "returns default_response if the function return is not a Response struct, a list of responses or a controller" do
+      route "/", fn(_) -> :ok end
+
+      response = HTTPoison.get! FakeServer.address <> "/"
+      assert response.status_code == 200
+      assert response.body == ~s<{"message": "This is a default response from FakeServer"}>
+    end
+
+    test_with_server "accepts the request object as argument" do
+      route "/", fn(req) ->
+        if :cowboy_req.qs_val("token", req) |> elem(0) == "1234" do
+          Response.ok
+        else
+          Response.forbidden
+        end
+      end
+
+      response = HTTPoison.get! FakeServer.address <> "/"
+      assert response.status_code == 403
+
+      response = HTTPoison.get! FakeServer.address <> "/?token=1234"
+      assert response.status_code == 200
     end
   end
 end

--- a/test/integration/fake_server_integration_test.exs
+++ b/test/integration/fake_server_integration_test.exs
@@ -372,15 +372,6 @@ defmodule FakeServer.FakeServerIntegrationTest do
       refute Enum.any?(response.headers, fn(header) -> header == {"Content-Type", "application/x-www-form-urlencoded"} end)
     end
 
-    test_with_server "test timeout" do
-      route "/", fn(_) ->
-        :timer.sleep(1_000)
-        FakeServer.HTTP.Response.ok
-      end
-      HTTPoison.get! FakeServer.address <> "/"
-    end
-
-
     test_with_server "create a list of responses" do
       person_list = FakeResponseFactory.build_list(3, :person)
 

--- a/test/integration/fake_server_integration_test.exs
+++ b/test/integration/fake_server_integration_test.exs
@@ -372,6 +372,15 @@ defmodule FakeServer.FakeServerIntegrationTest do
       refute Enum.any?(response.headers, fn(header) -> header == {"Content-Type", "application/x-www-form-urlencoded"} end)
     end
 
+    test_with_server "test timeout" do
+      route "/", fn(_) ->
+        :timer.sleep(1_000)
+        FakeServer.HTTP.Response.ok
+      end
+      HTTPoison.get! FakeServer.address <> "/"
+    end
+
+
     test_with_server "create a list of responses" do
       person_list = FakeResponseFactory.build_list(3, :person)
 

--- a/test/integration/fake_server_integration_test.exs
+++ b/test/integration/fake_server_integration_test.exs
@@ -448,6 +448,25 @@ defmodule FakeServer.FakeServerIntegrationTest do
       response = HTTPoison.get! FakeServer.address <> "/?token=1234&abc=def"
       assert response.status_code == 200
     end
+
+    test_with_server "can evaluate the request body" do
+      route "/", fn(req) ->
+        if req.body  == ~s<{"test": true}> do
+          Response.ok %{test: true}
+        else
+          Response.ok %{test: false}
+        end
+      end
+
+      address = FakeServer.address <> "/"
+
+      response = HTTPoison.post! address, ~s<{"test": true}>
+      assert response.status_code == 200
+      assert response.body == ~s<{"test":true}>
+
+      response = HTTPoison.post! address, ~s<{}>
+      assert response.body == ~s<{"test":false}>
+    end
   end
 end
 

--- a/test/integration/fake_server_integration_test.exs
+++ b/test/integration/fake_server_integration_test.exs
@@ -435,7 +435,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
 
     test_with_server "accepts the request object as argument" do
       route "/", fn(req) ->
-        if :cowboy_req.qs_val("token", req) |> elem(0) == "1234" do
+        if req.query["token"]  == "1234" do
           Response.ok
         else
           Response.forbidden
@@ -445,7 +445,7 @@ defmodule FakeServer.FakeServerIntegrationTest do
       response = HTTPoison.get! FakeServer.address <> "/"
       assert response.status_code == 403
 
-      response = HTTPoison.get! FakeServer.address <> "/?token=1234"
+      response = HTTPoison.get! FakeServer.address <> "/?token=1234&abc=def"
       assert response.status_code == 200
     end
   end

--- a/test/integration/support/fake_controllers.ex
+++ b/test/integration/support/fake_controllers.ex
@@ -5,8 +5,8 @@ defmodule FakeServer.Integration.FakeControllers do
     FakeServer.HTTP.Response.ok(~s<{"pet_name": "Rufus", "kind": "dog"}>)
   end
 
-  def query_string_controller(conn) do
-    if :cowboy_req.qs_val("token", conn) |> elem(0) == "1234" do
+  def query_string_controller(req) do
+    if req.query["token"] == "1234" do
       FakeServer.HTTP.Response.ok
     else
       FakeServer.HTTP.Response.unauthorized


### PR DESCRIPTION
This PR adds support to functions on routes and creates a Request struct to easy request evaluation.

## Usage:

```elixir
# ...
    test_with_server "can evaluate the request body" do
      route "/", fn(req) ->
        if req.body  == ~s<{"test": true}> do
          Response.ok %{test: true}
        else
          Response.ok %{test: false}
        end
      end

      address = FakeServer.address <> "/"

      response = HTTPoison.post! address, ~s<{"test": true}>
      assert response.status_code == 200
      assert response.body == ~s<{"test":true}>

      response = HTTPoison.post! address, ~s<{}>
      assert response.body == ~s<{"test":false}>
    end
# ...
```