### PR TITLE
fix agents tests when using elixir 1.6+

### DIFF
--- a/test/fake_server/agents/env_agent_test.exs
+++ b/test/fake_server/agents/env_agent_test.exs
@@ -25,7 +25,11 @@ defmodule FakeServer.Agents.EnvAgentTest do
     end
 
     test "throw :noproc error when stopping an agent that was not started" do
-      assert catch_exit(EnvAgent.stop) == :noproc
+      throw_value = case catch_exit(EnvAgent.stop) do
+        value when is_tuple(value) -> elem(value, 0)
+        value -> value
+      end
+      assert throw_value == :noproc
     end
   end
 

--- a/test/fake_server/agents/server_agent_test.exs
+++ b/test/fake_server/agents/server_agent_test.exs
@@ -25,7 +25,11 @@ defmodule FakeServer.Agents.ServerAgentTest do
     end
 
     test "throw :noproc error when stopping an agent that was not started" do
-      assert catch_exit(ServerAgent.stop) == :noproc
+      throw_value = case catch_exit(ServerAgent.stop) do
+        value when is_tuple(value) -> elem(value, 0)
+        value -> value
+      end
+      assert throw_value == :noproc
     end
   end
 


### PR DESCRIPTION
closes https://github.com/bernardolins/fake_server/issues/34

Check if catch_exit returns a tuple before asserting:

- if it does (elixir 16+): use the first element for assertion

- else: just use the assert with the return value as is