### PR TITLE
Use response from ok-tuple instead of silently ignoring it

### DIFF
--- a/lib/fake_server/server/handlers/function_handler.ex
+++ b/lib/fake_server/server/handlers/function_handler.ex
@@ -27,6 +27,7 @@ defmodule FakeServer.Handlers.FunctionHandler do
   defp execute_response(request, route) do
     case route.response.(request) do
       %Response{} = response -> response
+      {:ok, %Response{} = response} -> response
       _ -> Response.default!()
     end
   end


### PR DESCRIPTION
When using something like `Response.ok(...)` instead of
`Response.ok!(...)` in a handler function, the response is silently
replaced by the default response. Given that forgetting a single
characters happens easily, this change allows both a response and a
response wrapped in an ok-tuple.