### PR TITLE
Add test to show failure case for string factories.

### DIFF
--- a/test/integration/response_factory_test.exs
+++ b/test/integration/response_factory_test.exs
@@ -11,6 +11,13 @@ defmodule MyResponseFactory do
       %{"Content-Type" => "application/json"}
     )
   end
+
+  def plain_text_response do
+    ok(
+      "Hello World",
+      %{"Content-Type" => "text/plain"}
+    )
+  end
 end
 
 defmodule FakeServer.Integration.ResponseFactoryTest do
@@ -32,6 +39,13 @@ defmodule FakeServer.Integration.ResponseFactoryTest do
     assert person["email"] == body["email"]
     assert person["company"]["name"] == body["company"]["name"]
     assert person["company"]["country"] == body["company"]["country"]
+  end
+
+  test_with_server "basic factory usage with text" do
+    route("/plain", MyResponseFactory.build(:plain_text))
+    response = HTTPoison.get!(FakeServer.address() <> "/plain")
+
+    assert response.status_code == 200
   end
 
   test_with_server "setting custom attributes" do


### PR DESCRIPTION
This adds a test case to show that using the response factory for non-map types causes a failure when attempting to build them. This makes it difficult to use this library for testing non-JSON like responses.